### PR TITLE
Fix Umami tracking script URL

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,7 +16,7 @@ export default function Document() {
         />
         <script
           defer
-          src="https://analytics.eu.umami.is/script.js"
+          src="https://cloud.umami.is/script.js"
           data-website-id="3144784c-ff39-4ba4-90d6-1c4e945740c2"
         ></script>
       </Head>


### PR DESCRIPTION
## Summary
- update the Umami analytics script URL so events are tracked correctly

## Testing
- `npm install`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_6843f2034dc88329a71698f07568c25b